### PR TITLE
ELEMENTS-935: remove unused npm deps (1.0.x)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,10 +17,6 @@
     "lint": "npm run eslint && npm run polylint",
     "test": "polymer test --simpleOutput --expanded -l chrome"
   },
-  "dependencies": {
-    "@polymer/polymer": "^1.2.5-npm-test.2",
-    "nuxeo-elements": "nuxeo/nuxeo-elements"
-  },
   "devDependencies": {
     "web-component-tester": "*",
     "moment": "^2.10.6",


### PR DESCRIPTION
Backport of dependencies cleanup done in https://github.com/nuxeo/nuxeo-dataviz-elements/commit/63f40cf592dc0fee62ef159860a76b330f0d1d8d for 8.10.